### PR TITLE
Use ccflags instead of cflags

### DIFF
--- a/lib/ExtUtils/CBuilder/Base.pm
+++ b/lib/ExtUtils/CBuilder/Base.pm
@@ -64,7 +64,7 @@ sub new {
     }
     unless ( exists $self->{config}{cxx} ) {
       $self->{config}{cxx} = $self->{config}{cc};
-      my $cflags = $self->{config}{cflags};
+      my $cflags = $self->{config}{ccflags};
       $self->{config}{cxxflags} = '-x c++';
       $self->{config}{cxxflags} .= " $cflags" if defined $cflags;
     }


### PR DESCRIPTION
config cflags key was used, but it is defined nowhere. Nor Config.pm defines it, neither any code in the module. I think it is a typo for ccflags (as this PR changes), but please, confirm.

Meanwhile, checking if this fixes the problem I reported on p5p: "ExtUtils::CBuilder - cpp flags about archs"

Will report soon.
