### PR TITLE
fix C++ compiler finding

### DIFF
--- a/lib/ExtUtils/CBuilder/Base.pm
+++ b/lib/ExtUtils/CBuilder/Base.pm
@@ -44,14 +44,16 @@ sub new {
      if defined $ENV{LDFLAGS};
 
   unless ( exists $self->{config}{cxx} ) {
-    my ($ccpath, $ccbase, $ccsfx ) = fileparse($self->{config}{cc}, qr/\.[^.]*/);
+    my ($ccbase, $ccpath, $ccsfx ) = fileparse($self->{config}{cc}, qr/\.[^.]*/);
     foreach my $cxx (@{$cc2cxx{$ccbase}}) {
-      if( can_run( File::Spec->catfile( $ccpath, $cxx, $ccsfx ) ) ) {
-        $self->{config}{cxx} = File::Spec->catfile( $ccpath, $cxx, $ccsfx );
+      my $cxx1 = File::Spec->catfile( $ccpath, $cxx ) . $ccsfx;
+      if( can_run( $cxx1 ) ) {
+        $self->{config}{cxx} = $cxx1;
 	last;
       }
-      if( can_run( File::Spec->catfile( $cxx, $ccsfx ) ) ) {
-        $self->{config}{cxx} = File::Spec->catfile( $cxx, $ccsfx );
+      my $cxx2 = $cxx . $ccsfx;
+      if( can_run( $cxx2 ) ) {
+        $self->{config}{cxx} = $cxx2;
 	last;
       }
       if( can_run( $cxx ) ) {


### PR DESCRIPTION
There is bug in finding cxx in the system: Usage of fileparse() and catfile() were wrong. This caused it unable to find C++ compiler in some situations like SunCC on Solaris. For example, https://github.com/plicease/FFI-Platypus-Lang-CPP/issues/5 should be also caused by the bug. 