### PR TITLE
use can_run from EUMM rather than IPC::Cmd

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,6 +11,7 @@ version = 0.280234
 
 [OnlyCorePrereqs]
 starting_version = 5.014
+skip = ExtUtils::MakeMaker
 
 [@Filter]
 -bundle = @Basic
@@ -36,7 +37,7 @@ IO::File = 0
 IPC::Cmd = 0
 Text::ParseWords = 0
 Perl::OSType = 1
-ExtUtils::MakeMaker = 6.30
+ExtUtils::MakeMaker = 7.00
 
 [Prereqs / TestRequires]
 Test::More = 0.47

--- a/lib/ExtUtils/CBuilder/Base.pm
+++ b/lib/ExtUtils/CBuilder/Base.pm
@@ -6,7 +6,7 @@ use File::Basename;
 use Cwd ();
 use Config;
 use Text::ParseWords;
-use IPC::Cmd qw(can_run);
+use ExtUtils::MakeMaker ();
 use File::Temp qw(tempfile);
 
 # VERSION
@@ -55,18 +55,18 @@ sub new {
     foreach my $cxx (@{$cc2cxx{$ccbase}}) {
       my $cxx1 = File::Spec->catfile( $ccpath, $cxx . $ccsfx);
 
-      if( can_run( $cxx1 ) ) {
+      if( MM->can_run( $cxx1 ) ) {
         $self->{config}{cxx} = $cxx1;
 	last;
       }
       my $cxx2 = $cxx . $ccsfx;
 
-      if( can_run( $cxx2 ) ) {
+      if( MM->can_run( $cxx2 ) ) {
         $self->{config}{cxx} = $cxx2;
 	last;
       }
 
-      if( can_run( $cxx ) ) {
+      if( MM->can_run( $cxx ) ) {
         $self->{config}{cxx} = $cxx;
 	last;
       }


### PR DESCRIPTION
IPC::Cmd brings in a number of extra dependencies that are irrelevant to
the can_run function, which is the only part we are using. Internally,
IPC::Cmd::can_run calls functions in ExtUtils::MakeMaker. Newer versions
of EUMM provide a can_run method that provides the same functionality as
IPC::Cmd's. Just use the function from EUMM instead of IPC::Cmd.