### PR TITLE
print out commands being run in usable form

### DIFF
--- a/lib/ExtUtils/CBuilder/Base.pm
+++ b/lib/ExtUtils/CBuilder/Base.pm
@@ -336,10 +336,24 @@ sub _do_link {
   return wantarray ? ($out, @temp_files) : $out;
 }
 
+sub quote_literal {
+  my ($self, $string) = @_;
+
+  if (length $string && $string !~ /[^a-zA-Z0-9,._+@%\/-]/) {
+    return $string;
+  }
+
+  $string =~ s{'}{'\\''}g;
+
+  return "'$string'";
+}
 
 sub do_system {
   my ($self, @cmd) = @_;
-  print "@cmd\n" if !$self->{quiet};
+  if (!$self->{quiet}) {
+    my $full = join ' ', map $self->quote_literal($_), @cmd;
+    print $full . "\n";
+  }
   return !system(@cmd);
 }
 

--- a/lib/ExtUtils/CBuilder/Platform/Windows.pm
+++ b/lib/ExtUtils/CBuilder/Platform/Windows.pm
@@ -51,6 +51,22 @@ sub _compiler_type {
 	  : 'GCC');
 }
 
+# native quoting, not shell quoting
+sub quote_literal {
+  my ($self, $string) = @_;
+
+  # some of these characters don't need to be quoted for "native" quoting, but
+  # quote them anyway so they are more likely to make it through cmd.exe
+  if (length $string && $string !~ /[ \t\n\x0b"|<>%]/) {
+    return $string;
+  }
+
+  $string =~ s{(\\*)(?="|\z)}{$1$1}g;
+  $string =~ s{"}{\\"}g;
+
+  return qq{"$string"};
+}
+
 sub split_like_shell {
   # Since Windows will pass the whole command string (not an argument
   # array) to the target program and make the program parse it itself,
@@ -65,10 +81,15 @@ sub split_like_shell {
 sub do_system {
   # See above
   my $self = shift;
-  my $cmd = join(" ",
-		 grep length,
-		 map {$a=$_;$a=~s/\t/ /g;$a=~s/^\s+|\s+$//;$a}
-		 grep defined, @_);
+  my $cmd = join ' ',
+    grep length,
+    map {$a=$_;$a=~s/\t/ /g;$a=~s/^\s+|\s+$//;$a}
+    grep defined, @_;
+
+  if (!$self->{quiet}) {
+    print $cmd . "\n";
+  }
+  local $self->{quiet} = 1;
   return $self->SUPER::do_system($cmd);
 }
 


### PR DESCRIPTION
When not set to be quiet, the system commands being run are printed out
before running them. This can assist with diagnosing issues. It is
implied that this is a command that could be run by a user.

Since the command is internally run with system using list form, it does not
involve the shell, and does not need any extra quoting. The printed out
command however, would be run by a user through a shell. Just joining
the arguments with spaces will not quote them correctly for use through
a shell.

Add a new method for quoting a string for the shell. And use this method
when printing out the command line that we are running.